### PR TITLE
Priority queue

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,23 +1,41 @@
 from celery import Celery, signals
-from kombu import Queue
+from kombu import Queue, Exchange
 
 app = Celery("priority-test")
 
 app.conf.result_backend = "redis://dev:dev@localhost:6379"
 app.conf.broker_url = "redis://dev:dev@localhost:6379"
 
-app.conf.task_default_queue = "b-medium"
+#app.conf.task_default_queue = "b-medium"
 
 app.conf.task_create_missing_queues = True
 
-#app.conf.broker_transport_options = {"queue_order_strategy": "sorted"}
+#app.conf.task_default_priority = 3
+
+app.conf.broker_transport_options = {"queue_order_strategy": "sorted"}
 
 app.conf.worker_prefetch_multiplier = 1
 
+#app.conf.broker_transport_options = {
+#    'priority_steps': list(range(10)),
+#}
 
 app.conf.task_queues = (
-    Queue("a-high", routing_key="a-high"),
-    Queue("b-medium", routing_key="b-medium"),
-    Queue("c-low", routing_key="c-low"),
-    Queue("d-ghost", routing_key="d-ghost"),
+    Queue("a-high"),
+    Queue("b-medium"),
+    Queue("c-low"),
+    Queue("d-ghost"),
 )
+
+"""
+app.conf.task_queues = (
+    Queue('a-high', Exchange('default'), routing_key='a-high'),
+    Queue('b-medium',  Exchange('default'),   routing_key='b-medium'),
+    Queue('c-low',  Exchange('default'),   routing_key='c-low'),
+    Queue('d-ghost',  Exchange('default'),   routing_key='d-ghost'),
+)
+
+app.conf.task_default_queue = 'default'
+app.conf.task_default_exchange_type = 'direct'
+app.conf.task_default_routing_key = 'default'
+"""

--- a/test.py
+++ b/test.py
@@ -7,6 +7,12 @@ from celery import group, chord, chain
 # Queues:       a-high, b-medium, c-low, d-ghost
 
 
+"""
+NOTE:
+This first task fired in each test must ALWAYS assumed to finish first. This
+is because when the tasks fire, the queue is empty, so it has no other higher priority
+"""
+
 def hook(*args, **kwargs):
     print(args)
     print(kwargs)
@@ -112,21 +118,32 @@ class TestPriorityQueue(TestCase):
     def test_simple(self):
         """
         Test a simple FIFO queue with priority (de)escalation
+
+        This test shows that priority is honored above queue order
+        eg: given two queues, "a-work" and "b-work", and 3 tasks,
+        "t-1", "t-2", and "t-3", if t-1 and t-2 are in a, and t3 is in b,
+        they will complete in order (t1,t2,t3)
+
+        However, if t-2 has a priority of 0, and all others have a priority of 3,
+        they will complete: t-2, t-1, t-3
+
+        Further, if t-3 has a priority of 0, and t-1 and t-2 have a priority of 3,
+        they will complete: t-3, t-1, t-2
         """
         tasks = [
-            { "priority": 0, "fixture_name": "A", "queue":"a-high"},    # 1
-            { "priority": 0, "fixture_name": "B", "queue":"b-medium"},  # 3
-            { "priority": 0, "fixture_name": "C", "queue":"a-high"},    # 1
-            { "priority": 9, "fixture_name": "D", "queue":"a-high"},    # 2
-            { "priority": 0, "fixture_name": "E", "queue":"a-high"},    # 1
-            { "priority": 0, "fixture_name": "F", "queue":"b-medium"},  # 3
-            { "priority": 9, "fixture_name": "G", "queue":"a-high"},    # 2
-            { "priority": 0, "fixture_name": "H", "queue":"a-high"},    # 1
+            { "priority": 0, "fixture_name": "A", "queue":"a-high"},
+            { "priority": 0, "fixture_name": "B", "queue":"b-medium"},
+            { "priority": 9, "fixture_name": "C", "queue":"b-medium"},
+            { "priority": 3, "fixture_name": "D", "queue":"a-high"},
+            { "priority": 3, "fixture_name": "E", "queue":"a-high"},
+            { "priority": 3, "fixture_name": "F", "queue":"b-medium"},
+            { "priority": 3, "fixture_name": "G", "queue":"a-high"},
+            { "priority": 9, "fixture_name": "H", "queue":"a-high"},
         ]
         results = [] 
         for task in tasks:
-            t = wait.s(**task).set(queue=task["queue"])
-            results.append(t.apply_async(priority=task["priority"]))
+            t = wait.s(**task)
+            results.append(t.apply_async(priority=task["priority"], queue=task["queue"]))
 
         complete = False
         success = []
@@ -143,7 +160,6 @@ class TestPriorityQueue(TestCase):
 
         self.assertEqual(
             success,
-            ["A", "C", "E", "H", "D", "G", "B", "F"],
-            #['A', 'C', 'E', 'H', 'B', 'F', 'D', 'G']
+            ["A", "B", "D", "E", "G", "F", "H", "C"],
             "Numeric Priority not completed in expected order"
         )


### PR DESCRIPTION
        This test shows that priority is honored above queue order
        eg: given two queues, "a-work" and "b-work", and 3 tasks,
        "t-1", "t-2", and "t-3", if t-1 and t-2 are in a, and t3 is in b,
        they will complete in order (t1,t2,t3)

        However, if t-2 has a priority of 0, and all others have a priority of 3,
        they will complete: t-2, t-1, t-3

        Further, if t-3 has a priority of 0, and t-1 and t-2 have a priority of 3,
        they will complete: t-3, t-1, t-2